### PR TITLE
 Add cost tracking for alcohol consumption

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,6 +4,7 @@
       "Bash(grep:*)",
       "Bash(rm:*)"
     ],
-    "deny": []
+    "deny": [],
+    "defaultMode": "acceptEdits"
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
 - **Dual category support**: Tab-based interface for vaping (💨) and alcohol (🍷) tracking
 - **Modal-based entry creation**: All entries created through modal with date/time/note fields
 - **Craving intensity slider**: 3-level intensity scale (Mild, Medium, Strong) for cravings
+- **Cost tracking**: Alcohol consumption entries include cost field (£0.00-£10.00 range)
 - **Entry editing**: Edit any previous entry (date, time, type, note, intensity)
 - **Entry deletion**: Delete entries with confirmation dialog
 - **Navigation**: Seamless switching between Today and Timeline views
@@ -61,6 +62,7 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
 - **Interactive charts**: Hover values and scrollable day view
 - **Entry management**: Edit and delete entries directly from timeline day view
 - **Notes visibility toggle**: Burger menu option affects day activity list note display
+- **Cost analytics**: Total spending displayed per time period when alcohol filter is active
 
 ### Technical Features
 - **PWA capabilities**: Offline support, installable, cached resources
@@ -97,7 +99,8 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
   timestamp: ISO_string,            // Full date/time
   note: string,                     // Optional user note
   date: date_string,                // Cached toDateString() for filtering
-  intensity: 1|2|3                  // Craving intensity (1=Mild, 2=Medium, 3=Strong) - only for cravings
+  intensity: 1|2|3,                 // Craving intensity (1=Mild, 2=Medium, 3=Strong) - only for cravings
+  cost: number                      // Cost in GBP - only for alcohol consumption entries
 }
 ```
 
@@ -124,6 +127,14 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
 - **Dual chart types**: Bar charts for day/month/year views, line graph for week view
 - **Color coding**: Each category has distinct color scheme (vaping: blue/red, alcohol: purple/orange)
 - **Dynamic switching**: Chart type changes automatically based on selected time period
+
+### Cost Tracking System
+- **Entry-level costs**: Alcohol consumption entries can include cost (£0.00-£10.00 range)
+- **Cost slider**: Range input with 0.25 increments, displayed as currency
+- **Timeline aggregation**: Cost totals calculated per time period (day/week/month/year)
+- **Visual display**: Cost totals shown below time period labels when alcohol filter active
+- **Summary analytics**: Purple cost summary card shows total spending for selected period
+- **Conditional visibility**: Cost features only appear for alcohol category consumption entries
 
 ### Navigation Pattern
 - Both pages share identical header with navigation buttons
@@ -173,6 +184,13 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
 - Legacy entries auto-migrate to intensity 2
 - Slider component has CSS classes: `.intensity-slider`, `.intensity-labels`, `.intensity-value`
 
+### Working with Cost Data
+- Cost values: £0.00 to £10.00 in £0.25 increments (slider range 0-40, multiplied by 0.25)
+- Only applies to alcohol consumption entries (`type: 'smoked' && category: 'alcohol'`)
+- Cost slider shares CSS classes with intensity slider: `.intensity-slider`, `.intensity-value`
+- Timeline aggregation sums costs per time period: `alcoholCost` field in data objects
+- Display styling: `.cost-total` for individual period totals, `.cost-card` for summary cards
+
 ### Entry Management
 - **Edit functionality**: Both pages support full entry editing via shared modal system
 - **Delete functionality**: Confirmation dialog ("Are you sure you want to delete this entry?")
@@ -181,6 +199,7 @@ This is a **Craving Tracker** - a Progressive Web App (PWA) for addiction cessat
 
 ### Data Migration
 - Check `initializeApp()` methods in both classes for auto-migration logic
-- Update backup/restore logic handles new data fields (category, intensity)
+- Update backup/restore logic handles new data fields (category, intensity, cost)
 - Test import/export maintains data integrity
 - Legacy entries get default category 'vaping' and intensity 2 for cravings
+- Cost field defaults to null for entries that don't support it (vaping entries, cravings)

--- a/index.html
+++ b/index.html
@@ -512,6 +512,18 @@
             margin-top: 5px;
         }
 
+        .entry-cost {
+            color: #2d5a27;
+            font-weight: bold;
+            font-size: 14px;
+            margin-top: 5px;
+            background: #e8f5e8;
+            padding: 4px 8px;
+            border-radius: 4px;
+            display: inline-block;
+            border: 1px solid #b8e6b8;
+        }
+
         .entry-actions {
             display: flex;
             align-items: center;
@@ -932,6 +944,18 @@
                         <div class="intensity-value" id="intensityValue">Medium</div>
                     </div>
                 </div>
+                <div class="form-group" id="costGroup" style="display: none;">
+                    <label for="entryCost">Cost:</label>
+                    <div class="intensity-slider-container">
+                        <input type="range" id="entryCost" min="0" max="40" step="1" value="0" class="intensity-slider">
+                        <div class="intensity-labels">
+                            <span class="intensity-label">£0</span>
+                            <span class="intensity-label">£5</span>
+                            <span class="intensity-label">£10</span>
+                        </div>
+                        <div class="intensity-value" id="costValue">£0.00</div>
+                    </div>
+                </div>
                 <div class="form-group">
                     <label for="entryNote">Note (optional):</label>
                     <textarea id="entryNote" placeholder="Add details about this entry (triggers, feelings, situation, etc.)..."></textarea>
@@ -974,6 +998,18 @@
                             <span class="intensity-label">Strong</span>
                         </div>
                         <div class="intensity-value" id="editIntensityValue">Medium</div>
+                    </div>
+                </div>
+                <div class="form-group" id="editCostGroup" style="display: none;">
+                    <label for="editCost">Cost:</label>
+                    <div class="intensity-slider-container">
+                        <input type="range" id="editCost" min="0" max="40" step="1" value="0" class="intensity-slider">
+                        <div class="intensity-labels">
+                            <span class="intensity-label">£0</span>
+                            <span class="intensity-label">£5</span>
+                            <span class="intensity-label">£10</span>
+                        </div>
+                        <div class="intensity-value" id="editCostValue">£0.00</div>
                     </div>
                 </div>
                 <div class="form-group">
@@ -1287,6 +1323,14 @@
                 this.editIntensitySlider = document.getElementById('editIntensity');
                 this.editIntensityValue = document.getElementById('editIntensityValue');
                 this.editIntensityGroup = document.getElementById('editIntensityGroup');
+                
+                // Cost slider elements
+                this.costSlider = document.getElementById('entryCost');
+                this.costValue = document.getElementById('costValue');
+                this.costGroup = document.getElementById('costGroup');
+                this.editCostSlider = document.getElementById('editCost');
+                this.editCostValue = document.getElementById('editCostValue');
+                this.editCostGroup = document.getElementById('editCostGroup');
             }
 
             bindEvents() {
@@ -1324,6 +1368,14 @@
                 // Intensity slider events
                 this.intensitySlider.addEventListener('input', (e) => this.updateIntensityLabel(e.target.value, this.intensityValue));
                 this.editIntensitySlider.addEventListener('input', (e) => this.updateIntensityLabel(e.target.value, this.editIntensityValue));
+                
+                // Cost slider events
+                this.costSlider.addEventListener('input', (e) => this.updateCostLabel(e.target.value, this.costValue));
+                this.editCostSlider.addEventListener('input', (e) => this.updateCostLabel(e.target.value, this.editCostValue));
+                
+                // Entry type change events to show/hide appropriate sliders
+                document.getElementById('entryType').addEventListener('change', (e) => this.handleEntryTypeChange(e));
+                document.getElementById('editEntryType').addEventListener('change', (e) => this.handleEditEntryTypeChange(e));
                 
                 // Burger menu events
                 this.burgerBtn.addEventListener('click', () => this.toggleBurgerMenu());
@@ -1403,6 +1455,52 @@
                 labelElement.textContent = labels[parseInt(value)];
             }
 
+            updateCostLabel(value, labelElement) {
+                // Convert from 0-40 range to £0-£10 in £0.25 increments
+                const cost = (parseInt(value) * 0.25).toFixed(2);
+                labelElement.textContent = `£${cost}`;
+            }
+
+            handleEntryTypeChange(e) {
+                const type = e.target.value;
+                
+                // Show/hide intensity slider for cravings
+                if (type === 'craving') {
+                    this.intensityGroup.style.display = 'block';
+                    this.intensitySlider.value = 2;
+                    this.updateIntensityLabel(2, this.intensityValue);
+                } else {
+                    this.intensityGroup.style.display = 'none';
+                }
+                
+                // Show/hide cost slider for alcohol consumption
+                if (type === 'smoked' && this.currentCategory === 'alcohol') {
+                    this.costGroup.style.display = 'block';
+                    this.costSlider.value = 0;
+                    this.updateCostLabel(0, this.costValue);
+                } else {
+                    this.costGroup.style.display = 'none';
+                }
+            }
+
+            handleEditEntryTypeChange(e) {
+                const type = e.target.value;
+                
+                // Show/hide intensity slider for cravings
+                if (type === 'craving') {
+                    this.editIntensityGroup.style.display = 'block';
+                } else {
+                    this.editIntensityGroup.style.display = 'none';
+                }
+                
+                // Show/hide cost slider for alcohol consumption
+                if (type === 'smoked' && this.currentCategory === 'alcohol') {
+                    this.editCostGroup.style.display = 'block';
+                } else {
+                    this.editCostGroup.style.display = 'none';
+                }
+            }
+
             showEntryModal(type = null, isPastEntry = false) {
                 const now = new Date();
                 
@@ -1426,6 +1524,15 @@
                     this.updateIntensityLabel(2, this.intensityValue);
                 } else {
                     this.intensityGroup.style.display = 'none';
+                }
+                
+                // Show/hide cost slider based on category and entry type
+                if ((type === 'smoked' || (isPastEntry && !type)) && this.currentCategory === 'alcohol') {
+                    this.costGroup.style.display = 'block';
+                    this.costSlider.value = 0;
+                    this.updateCostLabel(0, this.costValue);
+                } else {
+                    this.costGroup.style.display = 'none';
                 }
                 
                 // Pre-fill form
@@ -1468,7 +1575,8 @@
                     timestamp: timestamp.toISOString(),
                     note: note,
                     date: timestamp.toDateString(),
-                    intensity: type === 'craving' ? parseInt(document.getElementById('entryIntensity').value) : null
+                    intensity: type === 'craving' ? parseInt(document.getElementById('entryIntensity').value) : null,
+                    cost: (type === 'smoked' && this.currentCategory === 'alcohol') ? (parseInt(document.getElementById('entryCost').value) * 0.25) : null
                 };
 
                 this.entries.push(entry);
@@ -1510,6 +1618,17 @@
                     editIntensityGroup.style.display = 'none';
                 }
                 
+                // Handle cost for alcohol consumption entries
+                const editCostGroup = document.getElementById('editCostGroup');
+                if (entry.type === 'smoked' && entry.category === 'alcohol') {
+                    editCostGroup.style.display = 'block';
+                    const costValue = entry.cost ? Math.round(entry.cost / 0.25) : 0; // Convert back to slider range (0-40)
+                    document.getElementById('editCost').value = costValue;
+                    this.updateCostLabel(costValue, this.editCostValue);
+                } else {
+                    editCostGroup.style.display = 'none';
+                }
+                
                 this.editEntryModal.style.display = 'block';
             }
 
@@ -1547,7 +1666,8 @@
                     timestamp: timestamp.toISOString(),
                     note: note,
                     date: timestamp.toDateString(),
-                    intensity: type === 'craving' ? parseInt(document.getElementById('editIntensity').value) : null
+                    intensity: type === 'craving' ? parseInt(document.getElementById('editIntensity').value) : null,
+                    cost: (type === 'smoked' && this.entries[entryIndex].category === 'alcohol') ? (parseInt(document.getElementById('editCost').value) * 0.25) : null
                 };
                 
                 // Re-sort entries by timestamp
@@ -1649,6 +1769,11 @@
                     const typeLabel = entry.type === 'craving' ? 'CRAVING' : 
                                     (entry.category === 'vaping' ? 'VAPED' : 'DRANK');
                     const typeColor = entry.type === 'craving' ? 'craving' : 'vaped';
+                    
+                    // Format cost display for alcohol entries
+                    const costDisplay = (entry.type === 'smoked' && entry.category === 'alcohol' && entry.cost !== null && entry.cost > 0) 
+                        ? `<div class="entry-cost">£${entry.cost.toFixed(2)}</div>` 
+                        : '';
 
                     return `
                         <div class="entry ${typeClass}">
@@ -1660,6 +1785,7 @@
                                     <button class="delete-btn" onclick="app.deleteEntry(${entry.id})" title="Delete entry">×</button>
                                 </div>
                             </div>
+                            ${costDisplay}
                             ${this.showNotes && entry.note ? `<div class="entry-note">"${entry.note}"</div>` : ''}
                         </div>
                     `;

--- a/shared-modal.js
+++ b/shared-modal.js
@@ -13,6 +13,15 @@ class ModalUtils {
         }
     }
 
+    // Update cost label display
+    static updateCostLabel(value, labelElement) {
+        if (labelElement) {
+            // Convert from 0-40 range to £0-£10 in £0.25 increments
+            const cost = (parseInt(value) * 0.25).toFixed(2);
+            labelElement.textContent = `£${cost}`;
+        }
+    }
+
     // Update type select options based on category
     static updateTypeOptions(selectElement, category) {
         if (category === 'vaping') {
@@ -35,6 +44,13 @@ class ModalUtils {
         }
     }
 
+    // Toggle cost visibility based on entry type and category
+    static toggleCostVisibility(costGroup, type, category) {
+        if (costGroup) {
+            costGroup.style.display = (type === 'smoked' && category === 'alcohol') ? 'block' : 'none';
+        }
+    }
+
     // Validate entry data
     static validateEntry(date, time) {
         const timestamp = new Date(`${date}T${time}`);
@@ -53,7 +69,7 @@ class ModalUtils {
     }
 
     // Create entry data object from form inputs
-    static createEntryData(type, date, time, note, category, intensityValue = null) {
+    static createEntryData(type, date, time, note, category, intensityValue = null, costValue = null) {
         const timestamp = new Date(`${date}T${time}`);
         
         return {
@@ -63,7 +79,8 @@ class ModalUtils {
             timestamp: timestamp.toISOString(),
             note: note,
             date: timestamp.toDateString(),
-            intensity: type === 'craving' ? intensityValue : null
+            intensity: type === 'craving' ? intensityValue : null,
+            cost: (type === 'smoked' && category === 'alcohol' && costValue !== null) ? costValue : null
         };
     }
 
@@ -95,6 +112,15 @@ class ModalUtils {
         }
     }
 
+    // Setup cost slider event handler
+    static setupCostSlider(slider, valueDisplay) {
+        if (slider && valueDisplay) {
+            slider.addEventListener('input', (e) => {
+                this.updateCostLabel(e.target.value, valueDisplay);
+            });
+        }
+    }
+
     // Populate edit form with entry data
     static populateEditForm(entry, elements) {
         const entryDate = new Date(entry.timestamp);
@@ -114,6 +140,16 @@ class ModalUtils {
             const intensity = entry.intensity || 2;
             elements.intensitySlider.value = intensity;
             this.updateIntensityLabel(intensity, elements.intensityValue);
+        }
+        
+        // Handle cost
+        if (elements.costGroup) {
+            this.toggleCostVisibility(elements.costGroup, entry.type, entry.category);
+            if (entry.type === 'smoked' && entry.category === 'alcohol' && elements.costSlider) {
+                const costValue = entry.cost ? Math.round(entry.cost / 0.25) : 0; // Convert back to slider range (0-40)
+                elements.costSlider.value = costValue;
+                this.updateCostLabel(costValue, elements.costValue);
+            }
         }
     }
 

--- a/timeline.html
+++ b/timeline.html
@@ -569,6 +569,14 @@
             transform-origin: center;
         }
 
+        .cost-total {
+            font-size: 10px;
+            color: #9b59b6;
+            text-align: center;
+            margin-top: 2px;
+            font-weight: 600;
+        }
+
         .bar-value {
             position: absolute;
             top: -20px;
@@ -646,6 +654,19 @@
             font-size: 12px;
             color: #666;
             margin-top: 5px;
+        }
+
+        .summary-card.cost-card {
+            background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%);
+            color: white;
+        }
+
+        .summary-card.cost-card .summary-number {
+            color: white;
+        }
+
+        .summary-card.cost-card .summary-label {
+            color: rgba(255, 255, 255, 0.9);
         }
 
         .empty-state {
@@ -733,6 +754,18 @@
             font-style: italic;
             margin-top: 5px;
             font-size: 14px;
+        }
+
+        .activity-cost {
+            color: #2d5a27;
+            font-weight: bold;
+            font-size: 14px;
+            margin-top: 5px;
+            background: #e8f5e8;
+            padding: 4px 8px;
+            border-radius: 4px;
+            display: inline-block;
+            border: 1px solid #b8e6b8;
         }
 
         .activity-actions {
@@ -1261,6 +1294,18 @@
                         <div class="intensity-value" id="editIntensityValue">Medium</div>
                     </div>
                 </div>
+                <div class="form-group" id="editCostGroup" style="display: none;">
+                    <label for="editCost">Cost:</label>
+                    <div class="intensity-slider-container">
+                        <input type="range" id="editCost" min="0" max="40" step="1" value="0" class="intensity-slider">
+                        <div class="intensity-labels">
+                            <span class="intensity-label">£0</span>
+                            <span class="intensity-label">£5</span>
+                            <span class="intensity-label">£10</span>
+                        </div>
+                        <div class="intensity-value" id="editCostValue">£0.00</div>
+                    </div>
+                </div>
                 <div class="form-group">
                     <label for="editNote">Note (optional):</label>
                     <textarea id="editNote" placeholder="Add details about this entry..."></textarea>
@@ -1532,6 +1577,9 @@
                 this.editIntensity = document.getElementById('editIntensity');
                 this.editIntensityValue = document.getElementById('editIntensityValue');
                 this.editIntensityGroup = document.getElementById('editIntensityGroup');
+                this.editCost = document.getElementById('editCost');
+                this.editCostValue = document.getElementById('editCostValue');
+                this.editCostGroup = document.getElementById('editCostGroup');
                 this.editNote = document.getElementById('editNote');
                 this.cancelEditBtn = document.getElementById('cancelEditBtn');
             }
@@ -1615,6 +1663,12 @@
                     this.editIntensity.addEventListener('input', (e) => this.updateIntensityLabel(e.target.value, this.editIntensityValue));
                 } else {
                     console.error('editIntensity not found');
+                }
+                
+                if (this.editCost) {
+                    this.editCost.addEventListener('input', (e) => ModalUtils.updateCostLabel(e.target.value, this.editCostValue));
+                } else {
+                    console.error('editCost not found');
                 }
                 
                 // Close edit modal when clicking outside
@@ -1807,10 +1861,16 @@
                         }
                     }
                     
+                    // Add cost display if alcohol filter is active and there's a cost
+                    const costDisplay = (this.activeFilters.has('alcohol') && item.alcoholCost > 0) 
+                        ? `<div class="cost-total">£${item.alcoholCost.toFixed(2)}</div>` 
+                        : '';
+
                     return `
                         <div class="bar-group ${this.currentPeriod === 'day' ? 'day-view' : ''}">
                             ${barElements}
                             <div class="bar-label ${needsRotation ? 'rotated' : ''}">${item.label}</div>
+                            ${costDisplay}
                         </div>
                     `;
                 }).join('');
@@ -1886,12 +1946,18 @@
                             if (cravingsCount > 0 || vapedCount > 0) {
                             }
                             
+                            // Calculate alcohol cost total for this hour
+                            const alcoholCost = hourEntries
+                                .filter(e => e.type === 'smoked' && e.category === 'alcohol' && e.cost)
+                                .reduce((sum, e) => sum + e.cost, 0);
+
                             data.push({
                                 label: hourLabel,
                                 vapingCravings: hourEntries.filter(e => e.type === 'craving' && e.category === 'vaping').length,
                                 vapingConsumed: hourEntries.filter(e => e.type === 'smoked' && e.category === 'vaping').length,
                                 alcoholCravings: hourEntries.filter(e => e.type === 'craving' && e.category === 'alcohol').length,
                                 alcoholConsumed: hourEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length,
+                                alcoholCost: alcoholCost,
                                 hour: hour
                             });
                         }
@@ -1914,12 +1980,18 @@
                                 return entryDate.toDateString() === weekDayString;
                             });
                             
+                            // Calculate alcohol cost total for this day
+                            const alcoholCost = dayEntries
+                                .filter(e => e.type === 'smoked' && e.category === 'alcohol' && e.cost)
+                                .reduce((sum, e) => sum + e.cost, 0);
+
                             data.push({
                                 label: weekDay.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }),
                                 vapingCravings: dayEntries.filter(e => e.type === 'craving' && e.category === 'vaping').length,
                                 vapingConsumed: dayEntries.filter(e => e.type === 'smoked' && e.category === 'vaping').length,
                                 alcoholCravings: dayEntries.filter(e => e.type === 'craving' && e.category === 'alcohol').length,
                                 alcoholConsumed: dayEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length,
+                                alcoholCost: alcoholCost,
                                 date: weekDayString
                             });
                         }
@@ -1951,12 +2023,18 @@
                                 
                                 // Only add months that have data or are recent (last 3 months)
                                 if (monthEntries.length > 0 || i <= 2) {
+                                    // Calculate alcohol cost total for this month
+                                    const alcoholCost = monthEntries
+                                        .filter(e => e.type === 'smoked' && e.category === 'alcohol' && e.cost)
+                                        .reduce((sum, e) => sum + e.cost, 0);
+
                                     data.push({
                                         label: monthDate.toLocaleDateString('en-US', { month: 'short', year: '2-digit' }),
                                         vapingCravings: monthEntries.filter(e => e.type === 'craving' && e.category === 'vaping').length,
                                         vapingConsumed: monthEntries.filter(e => e.type === 'smoked' && e.category === 'vaping').length,
                                         alcoholCravings: monthEntries.filter(e => e.type === 'craving' && e.category === 'alcohol').length,
-                                        alcoholConsumed: monthEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length
+                                        alcoholConsumed: monthEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length,
+                                        alcoholCost: alcoholCost
                                     });
                                 }
                             }
@@ -1967,12 +2045,19 @@
                         const years = [...new Set(this.entries.map(e => new Date(e.timestamp).getFullYear()))].sort();
                         years.forEach(year => {
                             const yearEntries = this.entries.filter(e => new Date(e.timestamp).getFullYear() === year);
+                            
+                            // Calculate alcohol cost total for this year
+                            const alcoholCost = yearEntries
+                                .filter(e => e.type === 'smoked' && e.category === 'alcohol' && e.cost)
+                                .reduce((sum, e) => sum + e.cost, 0);
+
                             data.push({
                                 label: year.toString(),
                                 vapingCravings: yearEntries.filter(e => e.type === 'craving' && e.category === 'vaping').length,
                                 vapingConsumed: yearEntries.filter(e => e.type === 'smoked' && e.category === 'vaping').length,
                                 alcoholCravings: yearEntries.filter(e => e.type === 'craving' && e.category === 'alcohol').length,
-                                alcoholConsumed: yearEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length
+                                alcoholConsumed: yearEntries.filter(e => e.type === 'smoked' && e.category === 'alcohol').length,
+                                alcoholCost: alcoholCost
                             });
                         });
                         break;
@@ -1987,7 +2072,8 @@
                     vapingCravings: data.reduce((sum, item) => sum + item.vapingCravings, 0),
                     vapingConsumed: data.reduce((sum, item) => sum + item.vapingConsumed, 0),
                     alcoholCravings: data.reduce((sum, item) => sum + item.alcoholCravings, 0),
-                    alcoholConsumed: data.reduce((sum, item) => sum + item.alcoholConsumed, 0)
+                    alcoholConsumed: data.reduce((sum, item) => sum + item.alcoholConsumed, 0),
+                    alcoholCost: data.reduce((sum, item) => sum + (item.alcoholCost || 0), 0)
                 };
 
                 const periodLabels = {
@@ -2022,6 +2108,10 @@
                         <div class="summary-card">
                             <div class="summary-number">${totals.alcoholConsumed}</div>
                             <div class="summary-label">Drank ${periodLabels[this.currentPeriod]}</div>
+                        </div>
+                        <div class="summary-card cost-card">
+                            <div class="summary-number">£${totals.alcoholCost.toFixed(2)}</div>
+                            <div class="summary-label">Spent ${periodLabels[this.currentPeriod]}</div>
                         </div>
                     `;
                 }
@@ -2072,10 +2162,16 @@
                     const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
                     const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
                     
+                    // Add cost display if alcohol filter is active and there's a cost
+                    const costDisplay = (this.activeFilters.has('alcohol') && item.alcoholCost > 0) 
+                        ? `<div class="cost-total">£${item.alcoholCost.toFixed(2)}</div>` 
+                        : '';
+                    
                     return `
                         <div class="line-graph-label">
                             <div class="weekday">${weekday}</div>
                             <div class="date">${dateStr}</div>
+                            ${costDisplay}
                         </div>
                     `;
                 }).join('');
@@ -2283,10 +2379,16 @@
                         typeLabel = entry.type === 'craving' ? 'ALCOHOL CRAVING' : 'DRANK';
                     }
 
+                    // Format cost display for alcohol entries
+                    const costDisplay = (entry.type === 'smoked' && entry.category === 'alcohol' && entry.cost !== null && entry.cost > 0) 
+                        ? `<div class="activity-cost">£${entry.cost.toFixed(2)}</div>` 
+                        : '';
+                        
                     return `
                         <div class="activity-entry ${entryClass}" data-entry-id="${entry.id}">
                             <div>
                                 <div class="activity-time">${timeString}</div>
+                                ${costDisplay}
                                 ${this.showNotes && entry.note ? `<div class="activity-note">${entry.note}</div>` : ''}
                             </div>
                             <div class="activity-actions">
@@ -2528,7 +2630,10 @@
                     noteInput: this.editNote,
                     intensityGroup: this.editIntensityGroup,
                     intensitySlider: this.editIntensity,
-                    intensityValue: this.editIntensityValue
+                    intensityValue: this.editIntensityValue,
+                    costGroup: this.editCostGroup,
+                    costSlider: this.editCost,
+                    costValue: this.editCostValue
                 };
                 
                 ModalUtils.populateEditForm(entry, elements);
@@ -2586,7 +2691,8 @@
                         timestamp: timestamp.toISOString(),
                         note: note,
                         date: timestamp.toDateString(),
-                        intensity: type === 'craving' ? parseInt(this.editIntensity.value) : null
+                        intensity: type === 'craving' ? parseInt(this.editIntensity.value) : null,
+                        cost: (type === 'smoked' && entry.category === 'alcohol') ? (parseInt(this.editCost.value) * 0.25) : null
                     };
                     
                     // Re-sort entries by timestamp


### PR DESCRIPTION
  - Add cost field (£0.00-£10.00) to alcohol consumption entries with slider input
  - Display cost totals per time period (day/week/month/year) in timeline views
  - Show cost information only when alcohol filter is active
  - Add purple cost summary card showing total spending for selected period
  - Include cost display below time period labels in all chart types
  - Update CLAUDE.md documentation with cost tracking implementation details

  Cost tracking provides users valuable insights into spending patterns alongside consumption data, enhancing the app's utility for alcohol cessation
  goals.